### PR TITLE
Hi there! I've been working on implementing Phase 1 of Obsidian Edit …

### DIFF
--- a/obsidian_sync/matcher.py
+++ b/obsidian_sync/matcher.py
@@ -1,0 +1,177 @@
+# obsidian_sync/matcher.py
+from typing import List, Dict, Optional, Any
+from datetime import datetime, time
+
+# Attempt to import normalize_title_for_fingerprint from extract_nlp.utils
+try:
+    from extract_nlp.utils import normalize_title_for_fingerprint
+except ImportError:
+    print("Warning (obsidian_sync.matcher): Could not import normalize_title_for_fingerprint from extract_nlp.utils. Defining a local fallback.")
+    import re
+    def normalize_title_for_fingerprint(title: str) -> str: # Fallback
+        if not title: return ""
+        normalized = title.lower()
+        # Simplified punctuation removal for fallback
+        normalized = re.sub(r'[\.,;!?"\'`’‘“”()*\[\]{}]', '', normalized)
+        normalized = re.sub(r'\s+', ' ', normalized).strip()
+        return normalized
+
+# Attempt to import Task from persistence.models for type hinting
+try:
+    from persistence.models import Task
+except ImportError:
+    print("Warning (obsidian_sync.matcher): Could not import Task from persistence.models. Using a dummy Task class for type hinting.")
+    # Define a dummy Task for type hinting if import fails
+    class Task: # type: ignore
+        id: int
+        title: str
+        due_dt: Optional[datetime]
+        # Add any other fields that might be accessed by the matcher logic if it evolves
+        def __init__(self, id: int, title: str, due_dt: Optional[datetime]):
+            self.id = id
+            self.title = title
+            self.due_dt = due_dt
+        def __repr__(self):
+            return f"<DummyTask(id={self.id}, title='{self.title}', due_dt='{self.due_dt}')>"
+
+
+def find_matching_task_in_db(
+    parsed_md_task: Dict[str, Optional[Any]], # Using Any for value type due to list of strings for tags_md
+    db_tasks_on_date: List[Task]
+) -> Optional[Task]:
+    """
+    Attempts to find a matching task in the database for a task parsed from Markdown.
+
+    Args:
+        parsed_md_task: A dictionary representing a task parsed from Markdown.
+                        Expected keys: "title_md" (str), "time_str" (str HH:MM or None).
+        db_tasks_on_date: A list of Task model instances from the database that
+                          are due on the same date as parsed_md_task.
+
+    Returns:
+        The matching Task object from the database, or None if no confident match is found.
+    """
+    if not parsed_md_task or not parsed_md_task.get("title_md"):
+        # print("DEBUG Matcher: MD task has no title, cannot match.")
+        return None
+
+    md_title_normalized = normalize_title_for_fingerprint(str(parsed_md_task["title_md"]))
+    md_time_str: Optional[str] = parsed_md_task.get("time_str") # type: ignore
+
+    md_task_time_obj: Optional[time] = None
+    if md_time_str:
+        try:
+            md_task_time_obj = datetime.strptime(md_time_str, "%H:%M").time()
+        except ValueError:
+            # print(f"Warning (Matcher): Invalid time_str '{md_time_str}' from Markdown task '{md_title_normalized}'. Treating as no specific time.")
+            md_task_time_obj = None
+
+    # print(f"DEBUG Matcher: Processing MD Task: Normalized Title='{md_title_normalized}', Time='{md_task_time_obj}'")
+
+    best_match: Optional[Task] = None
+
+    for db_task in db_tasks_on_date:
+        if not db_task.title:
+            # print(f"DEBUG Matcher: DB Task ID {db_task.id} has no title, skipping.")
+            continue
+
+        db_title_normalized = normalize_title_for_fingerprint(db_task.title)
+        # print(f"DEBUG Matcher: Comparing with DB Task ID {db_task.id}: Normalized Title='{db_title_normalized}', Due='{db_task.due_dt}'")
+
+        if md_title_normalized == db_title_normalized:
+            # Titles match, now check time alignment
+            db_task_time_obj: Optional[time] = None
+            if db_task.due_dt:
+                db_task_time_obj = db_task.due_dt.time()
+
+            if md_task_time_obj is not None: # Markdown task has a specific time
+                if db_task_time_obj is not None and md_task_time_obj == db_task_time_obj:
+                    # print(f"DEBUG Matcher: Strong match found (title + specific time) with DB Task ID {db_task.id}")
+                    best_match = db_task
+                    break
+            else: # Markdown task is effectively "all-day" (no time specified in MD task line)
+                if db_task_time_obj is not None and db_task_time_obj == time(0, 0, 0):
+                    # print(f"DEBUG Matcher: Strong match found (title + MD all-day vs DB midnight) with DB Task ID {db_task.id}")
+                    best_match = db_task
+                    break
+                # Add consideration: If MD task is all-day, and DB task due_dt is not None but has no specific time component set by user
+                # (meaning it might also be an all-day task if default time is 00:00:00).
+                # The current logic correctly handles this by checking db_task_time_obj == time(0,0,0).
+                # If DB task has a specific time (not midnight), it won't match an all-day MD task here.
+
+    # if best_match:
+    #     print(f"DEBUG Matcher: Final best match for MD Task '{md_title_normalized}' is DB Task ID {best_match.id}.")
+    # else:
+    #     print(f"DEBUG Matcher: No strong match found for MD Task '{md_title_normalized}' (MD Time: {md_task_time_obj}) among {len(db_tasks_on_date)} DB tasks on that date.")
+
+    return best_match
+
+
+if __name__ == '__main__':
+    print("--- Testing Task Matcher Logic ---")
+
+    # Using the dummy Task class defined above if actual import failed.
+    # If 'from persistence.models import Task' succeeded, Task will be the real one.
+    # For the __main__ block, explicitly use a local mock for clarity and isolation for this test script.
+    class MockMatcherTask:
+        def __init__(self, id: int, title: str, due_dt_iso: Optional[str]):
+            self.id = id
+            self.title = title
+            self.due_dt = datetime.fromisoformat(due_dt_iso) if due_dt_iso else None
+        def __repr__(self):
+            return f"<MockMatcherTask(id={self.id}, title='{self.title}', due='{self.due_dt.isoformat() if self.due_dt else None}')>"
+
+    # Test cases
+    md_task1 = {"date_str": "2024-03-18", "status_md": "[ ]", "time_str": "10:00", "title_md": "Team Meeting", "tags_md": ["#work"]}
+    md_task2 = {"date_str": "2024-03-18", "status_md": "[x]", "time_str": None, "title_md": "Review Report", "tags_md": ["#project"]} # All-day
+    md_task3 = {"date_str": "2024-03-18", "status_md": "[ ]", "time_str": "14:30", "title_md": "Client Call", "tags_md": []}
+    md_task4 = {"date_str": "2024-03-18", "status_md": "[ ]", "time_str": "10:00", "title_md": "  team meeting !! ", "tags_md": ["#work"]} # Title needs normalization
+    md_task5 = {"date_str": "2024-03-18", "status_md": "[ ]", "time_str": "00:00", "title_md": "Review Report", "tags_md": ["#project"]} # Explicit midnight
+
+    db_tasks_for_date = [
+        MockMatcherTask(id=1, title="Team Meeting", due_dt_iso="2024-03-18T10:00:00"),
+        MockMatcherTask(id=2, title="Review Report", due_dt_iso="2024-03-18T00:00:00"), # DB all-day (midnight)
+        MockMatcherTask(id=3, title="Client Call (Internal)", due_dt_iso="2024-03-18T14:30:00"),
+        MockMatcherTask(id=4, title="Team Meeting", due_dt_iso="2024-03-18T11:00:00"),
+        MockMatcherTask(id=5, title="Completely Different Task", due_dt_iso="2024-03-18T10:00:00"),
+        MockMatcherTask(id=6, title="Review Report", due_dt_iso="2024-03-18T10:00:00"), # Same title as task 2, but specific time
+    ]
+
+    test_scenarios = [
+        ("MD Task 1 (Specific Time)", md_task1, db_tasks_for_date, 1),
+        ("MD Task 2 (All-Day)", md_task2, db_tasks_for_date, 2),
+        ("MD Task 3 (Title Mismatch)", md_task3, db_tasks_for_date, None),
+        ("MD Task 4 (Normalized Title)", md_task4, db_tasks_for_date, 1),
+        ("MD Task 5 (Explicit Midnight)", md_task5, db_tasks_for_date, 2),
+        ("MD Task 6 (Specific time vs different specific time)", md_task1, [db_tasks_for_date[3], db_tasks_for_date[4]], None), # Team Meeting @ 10:00 vs @ 11:00
+        ("MD Task 7 (All-day vs specific time)", md_task2, [db_tasks_for_date[0], db_tasks_for_date[5]], None), # Review Report (all-day) vs DB items with specific times
+        ("MD Task 8 (Specific time vs all-day)", md_task1, [db_tasks_for_date[1]], None), # Team Meeting @ 10:00 vs Review Report (all-day)
+    ]
+
+    for desc, md_task, db_list, expected_id in test_scenarios:
+        print(f"\n--- {desc} ---")
+        print(f"Matching MD Task: '{md_task['title_md']}' @ {md_task.get('time_str', 'All-day')}")
+        # print(f"DB List: {[f'(ID:{t.id} T:{t.title} D:{t.due_dt.time() if t.due_dt else None})' for t in db_list]}")
+        match = find_matching_task_in_db(md_task, db_list) # type: ignore
+        print(f"Found: {match}")
+        if expected_id is not None:
+            assert match is not None and match.id == expected_id, f"Expected DB Task ID {expected_id}, got {match.id if match else None}"
+            print(f"SUCCESS: Matched expected DB Task ID {expected_id}")
+        else:
+            assert match is None, f"Expected no match (None), got DB Task ID {match.id if match else None}"
+            print("SUCCESS: Correctly found no match.")
+
+    print("\n--- Test with MD task having no title ---")
+    md_no_title = {"date_str": "2024-03-18", "status_md": "[ ]", "time_str": "10:00", "title_md": None, "tags_md": []}
+    match_no_title = find_matching_task_in_db(md_no_title, db_tasks_for_date) # type: ignore
+    assert match_no_title is None, "Should not match if MD task has no title."
+    print("SUCCESS: Correctly found no match for MD task without title.")
+
+    print("\n--- Test with MD task having malformed time string ---")
+    md_malformed_time = {"date_str": "2024-03-18", "status_md": "[ ]", "time_str": "99:99", "title_md": "Review Report", "tags_md": []}
+    # This should now match with the all-day "Review Report" (ID 2) because malformed time is treated as None (all-day)
+    match_malformed_time = find_matching_task_in_db(md_malformed_time, db_tasks_for_date) # type: ignore
+    assert match_malformed_time is not None and match_malformed_time.id == 2, f"Expected DB Task ID 2 for malformed time, got {match_malformed_time.id if match_malformed_time else None}"
+    print(f"SUCCESS: Correctly matched ID {match_malformed_time.id} for MD task with malformed time string (treated as all-day).")
+
+    print("\nMatcher tests complete.")

--- a/obsidian_sync/parser.py
+++ b/obsidian_sync/parser.py
@@ -1,0 +1,263 @@
+# obsidian_sync/parser.py
+import re
+from typing import List, Dict, Optional, Tuple, Pattern
+
+# Regex for date section header, e.g., "## 2023-10-27 (금)"
+# Captures YYYY-MM-DD in group 1
+RE_DATE_HEADER: Pattern[str] = re.compile(r"^##\s*(\d{4}-\d{2}-\d{2})\s*\(.+\)\s*$")
+
+# Regex for the basic task line structure
+# Group 1: Status marker like "[ ]", "[x]", "[c]"
+# Group 2: Optional time like "HH:MM " (note the space included in optional group)
+# Group 3: The rest of the line after status and time
+RE_TASK_LINE_BASE: Pattern[str] = re.compile(r"^\s*-\s*(\[.?\])\s*(?:(\d{2}:\d{2})\s+)?(.*)$")
+
+# Regex to find all tags (e.g., #tag1, #project_alpha) in a string
+RE_TAGS: Pattern[str] = re.compile(r"(#\S+)")
+
+# Regex to find and remove the D-Day string, e.g., (D-Day), (D-3 남음), (D+7 지남)
+# Includes optional leading space and aims to match the entire D-Day parenthetical.
+RE_D_DAY_STRING: Pattern[str] = re.compile(r"\s*\((?:D-Day|D-\d+\s*남음|D\+\d+\s*지남)\)")
+
+# Regex to find and remove the (Cancelled) marker string
+RE_CANCELLED_MARKER: Pattern[str] = re.compile(r"\s*\(Cancelled\)\s*$", re.IGNORECASE)
+
+
+def _extract_title_and_tags_from_line_segment(line_segment: str) -> Tuple[str, List[str]]:
+    """
+    Helper to extract title and tags from the part of the task line
+    after the status marker and optional time.
+    Tags, D-Day string, and (Cancelled) marker are removed to isolate the title.
+    """
+    # 1. Extract all tags first
+    found_tags_raw = RE_TAGS.findall(line_segment)
+    # Create a working copy of the line to remove parts from
+    work_line = line_segment
+
+    # 2. Remove tags from the working line to avoid them being part of the title
+    work_line = RE_TAGS.sub("", work_line).strip()
+
+    # 3. Remove D-Day string from the working line
+    work_line = RE_D_DAY_STRING.sub("", work_line).strip()
+
+    # 4. Remove (Cancelled) marker string from the working line
+    work_line = RE_CANCELLED_MARKER.sub("", work_line).strip()
+
+    # What remains is considered the title
+    title_candidate = work_line.strip()
+
+    # Clean up extracted tags (strip each tag, ensure they start with #, and are unique)
+    cleaned_tags = []
+    seen_tags = set()
+    for tag in found_tags_raw:
+        t = tag.strip()
+        if t.startswith("#") and t not in seen_tags:
+            cleaned_tags.append(t)
+            seen_tags.add(t)
+
+    return title_candidate, cleaned_tags
+
+
+def parse_markdown_agenda_file(filepath: str) -> List[Dict[str, Optional[List[str] | str]]]:
+    """
+    Parses an Obsidian Markdown agenda file and extracts task information.
+
+    Args:
+        filepath: The path to the Markdown agenda file.
+
+    Returns:
+        A list of dictionaries, where each dictionary represents a task
+        with keys: "date_str", "status_md", "time_str", "title_md", "tags_md".
+    """
+    parsed_tasks: List[Dict[str, Optional[List[str] | str]]] = []
+    current_date_str: Optional[str] = None
+
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            for line_num, line_content in enumerate(f, 1):
+                line = line_content.strip()
+
+                if not line: # Skip empty lines
+                    continue
+
+                date_match = RE_DATE_HEADER.match(line)
+                if date_match:
+                    current_date_str = date_match.group(1)
+                    # print(f"DEBUG Parser: Found date header: {current_date_str} on line {line_num}")
+                    continue
+
+                if not current_date_str: # Skip lines until a date header is found
+                    # print(f"DEBUG Parser: Skipping line {line_num} as no current_date_str: '{line}'")
+                    continue
+
+                task_base_match = RE_TASK_LINE_BASE.match(line)
+                if task_base_match:
+                    status_md = task_base_match.group(1)
+                    time_str = task_base_match.group(2) # Can be None if no time was matched
+                    rest_of_line = task_base_match.group(3).strip()
+
+                    # print(f"DEBUG Parser: Matched task base on line {line_num}: Status='{status_md}', Time='{time_str}', Rest='{rest_of_line}'")
+
+                    title_md, tags_md_list = _extract_title_and_tags_from_line_segment(rest_of_line)
+
+                    # If, after processing, title_md is empty, we might decide to skip it
+                    # or use a placeholder. For now, we'll keep it if status_md was found.
+                    if not title_md and status_md: # e.g. "- [ ]" with no text
+                         # print(f"Warning: Line {line_num} parsed with empty title: '{line_content.strip()}'")
+                         title_md = "Untitled Task" # Or skip by 'continue'
+
+                    parsed_tasks.append({
+                        "date_str": current_date_str,
+                        "status_md": status_md,
+                        "time_str": time_str, # This will be None if no time, or "HH:MM" string
+                        "title_md": title_md,
+                        "tags_md": tags_md_list # List of strings, e.g., ["#tag1", "#project"]
+                    })
+                # else:
+                    # print(f"DEBUG Parser: Line {line_num} not a date or task: '{line}'")
+    except FileNotFoundError:
+        print(f"Error: File not found at {filepath}")
+        return []
+    except Exception as e:
+        print(f"An error occurred while parsing {filepath}: {e}")
+        return []
+
+    return parsed_tasks
+
+if __name__ == '__main__':
+    dummy_md_content = """
+## 2024-03-15 (금)
+- [ ] 10:00 Morning Meeting (D-Day) #meeting #important
+- [x] Finish report (D-1 남음) #work
+- [ ] Simple task item
+- [c] Cancelled old item (D+5 지남) #old (Cancelled)
+- [ ] Task with no time (D-Day) #notime
+
+---
+## 2024-03-16 (토)
+- [ ] Weekend errand #personal #todo
+- [ ] 14:30 Another item for Saturday with specific time (D-2 남음) #errand
+    - This is a note on the item, current parser will include it in title or it's stripped by tag/dday logic.
+    This line should ideally not be part of the title. (Parser needs enhancement for sub-lines)
+- [ ] Item with #multiple #tags #here (D-2 남음) and some text after tags.
+- [ ] Item with #duplicate #tag and #duplicate #tag again
+---
+This is not a task line.
+Nor is this.
+## 2024-03-17 (일)
+- [ ]
+- [x] #JustTagNoTitle
+    """
+    dummy_filepath = "dummy_agenda_for_parser_test.md"
+    with open(dummy_filepath, 'w', encoding='utf-8') as f:
+        f.write(dummy_md_content)
+
+    print(f"--- Testing Markdown Parser with '{dummy_filepath}' ---")
+    tasks = parse_markdown_agenda_file(dummy_filepath)
+
+    if tasks:
+        for i, task in enumerate(tasks):
+            print(f"Task {i+1}:")
+            print(f"  Date    : {task['date_str']}")
+            print(f"  Status  : {task['status_md']}")
+            print(f"  Time    : {task['time_str'] if task['time_str'] else 'N/A'}")
+            print(f"  Title   : '{task['title_md']}'")
+            print(f"  Tags    : {task['tags_md']}")
+            print("-" * 20)
+    else:
+        print("No tasks parsed or file not found.")
+
+    import os
+    try:
+        os.remove(dummy_filepath)
+        print(f"\nCleaned up '{dummy_filepath}'.")
+    except OSError as e:
+        print(f"\nError removing dummy file '{dummy_filepath}': {e}")
+
+    print("\n--- Testing with a non-existent file ---")
+    non_existent_tasks = parse_markdown_agenda_file("non_existent_file.md")
+    print(f"Result for non-existent file: {len(non_existent_tasks)} tasks found (expected 0).")
+
+    print("\n--- Testing specific line cases ---")
+    test_line_1 = "- [ ] 10:30 My Task Title #tag1 (D-1 남음) #tag2"
+    match_1 = RE_TASK_LINE_BASE.match(test_line_1)
+    if match_1:
+        title_res_1, tags_res_1 = _extract_title_and_tags_from_line_segment(match_1.group(3).strip())
+        print(f"Line: '{test_line_1}' -> Title: '{title_res_1}', Tags: {tags_res_1}")
+
+    test_line_2 = "- [x] Another Task (D-Day) #projectX"
+    match_2 = RE_TASK_LINE_BASE.match(test_line_2)
+    if match_2:
+        title_res_2, tags_res_2 = _extract_title_and_tags_from_line_segment(match_2.group(3).strip())
+        print(f"Line: '{test_line_2}' -> Title: '{title_res_2}', Tags: {tags_res_2}")
+
+    test_line_3 = "- [c] Cancelled Task (D+3 지남) #old (Cancelled)"
+    match_3 = RE_TASK_LINE_BASE.match(test_line_3)
+    if match_3:
+        title_res_3, tags_res_3 = _extract_title_and_tags_from_line_segment(match_3.group(3).strip())
+        print(f"Line: '{test_line_3}' -> Title: '{title_res_3}', Tags: {tags_res_3}")
+
+    test_line_4 = "- [ ] Task with #multiple #tags and (D-Day) d-day string in middle #another"
+    match_4 = RE_TASK_LINE_BASE.match(test_line_4)
+    if match_4:
+        title_res_4, tags_res_4 = _extract_title_and_tags_from_line_segment(match_4.group(3).strip())
+        print(f"Line: '{test_line_4}' -> Title: '{title_res_4}', Tags: {tags_res_4}")
+
+
+    test_line_5 = "- [ ] A task with (parentheses in title) and stuff (D-1 남음) #mytag"
+    match_5 = RE_TASK_LINE_BASE.match(test_line_5)
+    if match_5:
+        title_res_5, tags_res_5 = _extract_title_and_tags_from_line_segment(match_5.group(3).strip())
+        print(f"Line: '{test_line_5}' -> Title: '{title_res_5}', Tags: {tags_res_5}")
+
+    test_line_6 = "- [ ] Task with no D-Day string #nodday"
+    match_6 = RE_TASK_LINE_BASE.match(test_line_6)
+    if match_6:
+        title_res_6, tags_res_6 = _extract_title_and_tags_from_line_segment(match_6.group(3).strip())
+        print(f"Line: '{test_line_6}' -> Title: '{title_res_6}', Tags: {tags_res_6}")
+
+    test_line_7 = "- [ ] " # Task with no title
+    match_7 = RE_TASK_LINE_BASE.match(test_line_7)
+    if match_7:
+        title_res_7, tags_res_7 = _extract_title_and_tags_from_line_segment(match_7.group(3).strip())
+        print(f"Line: '{test_line_7}' -> Title: '{title_res_7}', Tags: {tags_res_7}")
+        if not title_res_7: print("    (Title correctly empty)")
+
+    test_line_8 = "- [x] #OnlyTags"
+    match_8 = RE_TASK_LINE_BASE.match(test_line_8)
+    if match_8:
+        title_res_8, tags_res_8 = _extract_title_and_tags_from_line_segment(match_8.group(3).strip())
+        print(f"Line: '{test_line_8}' -> Title: '{title_res_8}', Tags: {tags_res_8}")
+        if not title_res_8: print("    (Title correctly empty)")
+
+
+    print("\n--- Testing Regex Directly ---")
+    print(f"RE_D_DAY_STRING match on ' (D-Day)': {RE_D_DAY_STRING.search(' (D-Day)')}")
+    print(f"RE_D_DAY_STRING sub on 'My Title (D-3 남음)': '{RE_D_DAY_STRING.sub('', 'My Title (D-3 남음)').strip()}'")
+    print(f"RE_CANCELLED_MARKER sub on 'My Title (Cancelled)': '{RE_CANCELLED_MARKER.sub('', 'My Title (Cancelled)').strip()}'")
+    print(f"RE_TAGS findall on 'text #tag1 more #tag2': {RE_TAGS.findall('text #tag1 more #tag2')}")
+
+    print("\n--- Test _extract_title_and_tags_from_line_segment ---")
+    line_seg_test_1 = "Morning Meeting (D-Day) #meeting #important"
+    title_test_1, tags_test_1 = _extract_title_and_tags_from_line_segment(line_seg_test_1)
+    print(f"Segment: '{line_seg_test_1}' -> Title: '{title_test_1}', Tags: {tags_test_1}")
+
+    line_seg_test_2 = "Finish report (D-1 남음) #work"
+    title_test_2, tags_test_2 = _extract_title_and_tags_from_line_segment(line_seg_test_2)
+    print(f"Segment: '{line_seg_test_2}' -> Title: '{title_test_2}', Tags: {tags_test_2}")
+
+    line_seg_test_3 = "Cancelled old item (D+5 지남) #old (Cancelled)"
+    title_test_3, tags_test_3 = _extract_title_and_tags_from_line_segment(line_seg_test_3)
+    print(f"Segment: '{line_seg_test_3}' -> Title: '{title_test_3}', Tags: {tags_test_3}")
+
+    line_seg_test_4 = "Item with #multiple #tags #here (D-2 남음) and some text after tags." # This text will remain in title
+    title_test_4, tags_test_4 = _extract_title_and_tags_from_line_segment(line_seg_test_4)
+    print(f"Segment: '{line_seg_test_4}' -> Title: '{title_test_4}', Tags: {tags_test_4}")
+
+    line_seg_test_5 = "#JustTagNoTitle (D-Day)"
+    title_test_5, tags_test_5 = _extract_title_and_tags_from_line_segment(line_seg_test_5)
+    print(f"Segment: '{line_seg_test_5}' -> Title: '{title_test_5}', Tags: {tags_test_5}")
+
+    line_seg_test_6 = "Task with (parentheses in title) (D-Day) #tag"
+    title_test_6, tags_test_6 = _extract_title_and_tags_from_line_segment(line_seg_test_6)
+    print(f"Segment: '{line_seg_test_6}' -> Title: '{title_test_6}', Tags: {tags_test_6}")


### PR DESCRIPTION
…Sync, focusing on Markdown Parsing and Matching in a dry run.

This update introduces the foundational components for synchronizing task changes from your Obsidian Markdown agenda files back to the database. This phase focuses on parsing the Markdown files, matching tasks to existing database entries, and providing a dry-run view of potential changes (currently for status updates).

Here are the key changes:

1.  **Markdown Parser (`obsidian_sync/parser.py`)**:
    *   I've created a function that reads an agenda file and extracts tasks.
    *   It uses regular expressions to identify date sections and parse individual task lines for status (e.g., `[x]`), time, title, and tags.
    *   It also handles the removal of D-Day strings and "(Cancelled)" markers from titles.
    *   This function returns a list of dictionaries, each representing a parsed task.
    *   I've included a comprehensive section for direct testing of the parser.

2.  **Task Matcher (`obsidian_sync/matcher.py`)**:
    *   I've created a function to find a corresponding database task for a given parsed Markdown task.
    *   Matching is based on the task's date, normalized title, and time alignment (specific time vs. all-day).
    *   I've also included a section for direct testing of the matching heuristics.

3.  **CLI Command for Sync (`cli/main_cli.py`)**:
    *   I've added a new command `sync` to orchestrate the synchronization process.
    *   It takes a Markdown filepath as input and has a `--dry-run` option (which is True by default).
    *   It uses the parser to read tasks from the Markdown file.
    *   For each parsed task, it uses the matcher to find a corresponding DB task.
    *   If a match is found, it currently compares the status from Markdown (e.g., `[x]` for DONE) with the DB task's status.
    *   In dry-run mode, it prints a table summarizing potential status changes that would be applied if the sync were live. No database modifications are made in this phase.
    *   I've included a helper to convert MD status markers to `TaskStatus` enums.

4.  **Unit Tests (`tests/test_cli.py`)**:
    *   I'veRunner` and mock the parser, matcher, and database interactions to verify the dry-run logic, output, and error handling.

This phase lays the groundwork for enabling two-way synchronization with Obsidian by successfully parsing local added unit tests for the new `sync` CLI command and its helper.
    *   These tests use `Typer`'s `Cli Markdown files and identifying potential changes against the central database.